### PR TITLE
More flexible LDAP and default ACLs

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -8,6 +8,9 @@ scmRepo=http://myserver.com/@rev1=
 scmRepoPath=//appconfig.txt
 #if set to true then userSet is used for authentication, else ldap authentication is used.
 ldapAuth=false
+userSet = {"users": [{ "username":"admin" , "password":"manager","role": "ADMIN" },{ "username":"appconfig" , "password":"appconfig","role": "USER" }]}
+#ldap authentication url. Ignore if using file based authentication.
+ldapUrl=ldap://<ldap_host>:<ldap_port>/dc=mycom,dc=com
 ldapDomain=mycompany,mydomain
 # is ldap is being used, this is the format used to generate the principal from the domain and the username.
 # %1$s will be replaced with the domain name, and %2$s will be replaced with the username.
@@ -16,9 +19,6 @@ ldapDomain=mycompany,mydomain
 ldapPrincipalTemplate=%1$s\\\\%2$s
 ldapGroupMatchAttrId=cn
 ldapGroupSearchBase=cn=groups,cn=compat,dc=mycompany,dc=com
-userSet = {"users": [{ "username":"admin" , "password":"manager","role": "ADMIN" },{ "username":"appconfig" , "password":"appconfig","role": "USER" }]}
-#ldap authentication url. Ignore if using file based authentication.
-ldapUrl=ldap://<ldap_host>:<ldap_port>/dc=mycom,dc=com
 #Specific roles for ldap authenticated users. Ignore if using file based authentication.
 ldapRoleSet={"users": [{ "username":"domain\\user1" , "role": "ADMIN" }]}
 #Specific roles for ldap authenticated users by group. Ignore if using file based authentication.

--- a/config.cfg
+++ b/config.cfg
@@ -9,11 +9,23 @@ scmRepoPath=//appconfig.txt
 #if set to true then userSet is used for authentication, else ldap authentication is used.
 ldapAuth=false
 ldapDomain=mycompany,mydomain
+# is ldap is being used, this is the format used to generate the principal from the domain and the username.
+# %1$s will be replaced with the domain name, and %2$s will be replaced with the username.
+# This is the AD standard template.  Other ldap systems use others, such as
+# ldapPrincipalTemplate=uid=%2$s,cn=users,cn=accounts,dc=mycompany,dc=com
+ldapPrincipalTemplate=%1$s\\\\%2$s
+ldapGroupMatchAttrId=cn
+ldapGroupSearchBase=cn=groups,cn=compat,dc=mycompany,dc=com
 userSet = {"users": [{ "username":"admin" , "password":"manager","role": "ADMIN" },{ "username":"appconfig" , "password":"appconfig","role": "USER" }]}
 #ldap authentication url. Ignore if using file based authentication.
 ldapUrl=ldap://<ldap_host>:<ldap_port>/dc=mycom,dc=com
 #Specific roles for ldap authenticated users. Ignore if using file based authentication.
 ldapRoleSet={"users": [{ "username":"domain\\user1" , "role": "ADMIN" }]}
+#Specific roles for ldap authenticated users by group. Ignore if using file based authentication.
+#If groupsToTest is not empty, then users must belong to at least one of the groups or they will not
+#be authorized - even though they are authenticated
+ldapGroupsToTest=
+ldapGroupRoleSet={"groups": [{"groupname":"zookeeper-admin", "role":"ADMIN"}, {"groupname":"zookeeper-user", "role":"USER"}]}
 #Set to prod in production and dev in local. Setting to dev will clear history each time.
 env=prod
 jdbcClass=org.h2.Driver

--- a/config.cfg
+++ b/config.cfg
@@ -42,3 +42,7 @@ loginMessage=Please login using admin/manager or appconfig/appconfig.
 sessionTimeout=300
 #Block PWD exposure over rest call.
 blockPwdOverRest=false
+# The default ACL to use for all creation of nodes. If left blank, then all nodes will be universally accessible
+# Permissions are based on single character flags: c (Create), r (read), w (write), d (delete), a (admin), * (all)
+# For example defaultAcl={"acls": [{"scheme":"ip", "id":"192.168.1.192", "perms":"*"}, {"scheme":"ip", id":"192.168.1.0/24", "perms":"r"}]
+defaultAcl=

--- a/src/main/java/com/deem/zkui/controller/Export.java
+++ b/src/main/java/com/deem/zkui/controller/Export.java
@@ -56,7 +56,7 @@ public class Export extends HttpServlet {
             String zkPath = request.getParameter("zkPath");
             StringBuilder output = new StringBuilder();
             output.append("#App Config Dashboard (ACD) dump created on :").append(new Date()).append("\n");
-            Set<LeafBean> leaves = ZooKeeperUtil.INSTANCE.exportTree(zkPath, ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0]), authRole);
+            Set<LeafBean> leaves = ZooKeeperUtil.INSTANCE.exportTree(zkPath, ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0], globalProps), authRole);
             for (LeafBean leaf : leaves) {
                 output.append(leaf.getPath()).append('=').append(leaf.getName()).append('=').append(ServletUtil.INSTANCE.externalizeNodeValue(leaf.getValue())).append('\n');
             }// for all leaves

--- a/src/main/java/com/deem/zkui/controller/Home.java
+++ b/src/main/java/com/deem/zkui/controller/Home.java
@@ -56,7 +56,7 @@ public class Home extends HttpServlet {
             Map<String, Object> templateParam = new HashMap<>();
             String zkPath = request.getParameter("zkPath");
             String navigate = request.getParameter("navigate");
-            ZooKeeper zk = ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0]);
+            ZooKeeper zk = ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0], globalProps);
             List<String> nodeLst;
             List<LeafBean> leafLst;
             String currentPath, parentPath, displayPath;
@@ -130,7 +130,7 @@ public class Home extends HttpServlet {
                 case "Save Node":
                     if (!newNode.equals("") && !currentPath.equals("") && authRole.equals(ZooKeeperUtil.ROLE_ADMIN)) {
                         //Save the new node.
-                        ZooKeeperUtil.INSTANCE.createFolder(currentPath + newNode, "foo", "bar", ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0]));
+                        ZooKeeperUtil.INSTANCE.createFolder(currentPath + newNode, "foo", "bar", ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0], globalProps));
                         request.getSession().setAttribute("flashMsg", "Node created!");
                         dao.insertHistory((String) request.getSession().getAttribute("authName"), request.getRemoteAddr(), "Creating node: " + currentPath + newNode);
                     }
@@ -139,7 +139,7 @@ public class Home extends HttpServlet {
                 case "Save Property":
                     if (!newProperty.equals("") && !currentPath.equals("") && authRole.equals(ZooKeeperUtil.ROLE_ADMIN)) {
                         //Save the new node.
-                        ZooKeeperUtil.INSTANCE.createNode(currentPath, newProperty, newValue, ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0]));
+                        ZooKeeperUtil.INSTANCE.createNode(currentPath, newProperty, newValue, ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0], globalProps));
                         request.getSession().setAttribute("flashMsg", "Property Saved!");
                         if (ZooKeeperUtil.INSTANCE.checkIfPwdField(newProperty)) {
                             newValue = ZooKeeperUtil.INSTANCE.SOPA_PIPA;
@@ -151,7 +151,7 @@ public class Home extends HttpServlet {
                 case "Update Property":
                     if (!newProperty.equals("") && !currentPath.equals("") && authRole.equals(ZooKeeperUtil.ROLE_ADMIN)) {
                         //Save the new node.
-                        ZooKeeperUtil.INSTANCE.setPropertyValue(currentPath, newProperty, newValue, ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0]));
+                        ZooKeeperUtil.INSTANCE.setPropertyValue(currentPath, newProperty, newValue, ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0], globalProps));
                         request.getSession().setAttribute("flashMsg", "Property Updated!");
                         if (ZooKeeperUtil.INSTANCE.checkIfPwdField(newProperty)) {
                             newValue = ZooKeeperUtil.INSTANCE.SOPA_PIPA;
@@ -161,7 +161,7 @@ public class Home extends HttpServlet {
                     response.sendRedirect("/home?zkPath=" + displayPath);
                     break;
                 case "Search":
-                    Set<LeafBean> searchResult = ZooKeeperUtil.INSTANCE.searchTree(searchStr, ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0]), authRole);
+                    Set<LeafBean> searchResult = ZooKeeperUtil.INSTANCE.searchTree(searchStr, ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0], globalProps), authRole);
                     templateParam.put("searchResult", searchResult);
                     ServletUtil.INSTANCE.renderHtml(request, response, templateParam, "search.ftl.html");
                     break;
@@ -171,7 +171,7 @@ public class Home extends HttpServlet {
                         if (propChkGroup != null) {
                             for (String prop : propChkGroup) {
                                 List delPropLst = Arrays.asList(prop);
-                                ZooKeeperUtil.INSTANCE.deleteLeaves(delPropLst, ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0]));
+                                ZooKeeperUtil.INSTANCE.deleteLeaves(delPropLst, ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0], globalProps));
                                 request.getSession().setAttribute("flashMsg", "Delete Completed!");
                                 dao.insertHistory((String) request.getSession().getAttribute("authName"), request.getRemoteAddr(), "Deleting Property: " + delPropLst.toString());
                             }
@@ -179,7 +179,7 @@ public class Home extends HttpServlet {
                         if (nodeChkGroup != null) {
                             for (String node : nodeChkGroup) {
                                 List delNodeLst = Arrays.asList(node);
-                                ZooKeeperUtil.INSTANCE.deleteFolders(delNodeLst, ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0]));
+                                ZooKeeperUtil.INSTANCE.deleteFolders(delNodeLst, ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0], globalProps));
                                 request.getSession().setAttribute("flashMsg", "Delete Completed!");
                                 dao.insertHistory((String) request.getSession().getAttribute("authName"), request.getRemoteAddr(), "Deleting Nodes: " + delNodeLst.toString());
                             }

--- a/src/main/java/com/deem/zkui/controller/Import.java
+++ b/src/main/java/com/deem/zkui/controller/Import.java
@@ -136,7 +136,7 @@ public class Import extends HttpServlet {
             }
             br.close();
 
-            ZooKeeperUtil.INSTANCE.importData(importFile, Boolean.valueOf(scmOverwrite), ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0]));
+            ZooKeeperUtil.INSTANCE.importData(importFile, Boolean.valueOf(scmOverwrite), ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0], globalProps));
             for (String line : importFile) {
                 if (line.startsWith("-")) {
                     dao.insertHistory((String) request.getSession().getAttribute("authName"), request.getRemoteAddr(), "File: " + uploadFileName + ", Deleting Entry: " + line);

--- a/src/main/java/com/deem/zkui/controller/Login.java
+++ b/src/main/java/com/deem/zkui/controller/Login.java
@@ -113,9 +113,9 @@ public class Login extends HttpServlet {
                                     (JSONArray) ((JSONObject) new JSONParser().parse(globalProps.getProperty("ldapGroupRoleSet"))).get("groups");
                             groupRoleLoop: for (Iterator it = jsonGroupRoleSet.iterator(); it.hasNext();) {
                                 JSONObject jsonGroupRole = (JSONObject) it.next();
-                                if (jsonGroupRole.get("gruopname") != null) {
+                                if (jsonGroupRole.get("groupname") != null) {
                                     for (String group : authenticatedGroups) {
-                                        if (jsonGroupRole.get("gruopname").equals(group)) {
+                                        if (jsonGroupRole.get("groupname").equals(group)) {
                                             role = (String) jsonGroupRole.get("role");
                                             // First one wins
                                             break groupRoleLoop;

--- a/src/main/java/com/deem/zkui/controller/Logout.java
+++ b/src/main/java/com/deem/zkui/controller/Logout.java
@@ -43,7 +43,7 @@ public class Logout extends HttpServlet {
             Properties globalProps = (Properties) getServletContext().getAttribute("globalProps");
             String zkServer = globalProps.getProperty("zkServer");
             String[] zkServerLst = zkServer.split(",");
-            ZooKeeper zk = ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0]);
+            ZooKeeper zk = ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0], globalProps);
             request.getSession().invalidate();
             zk.close();
             response.sendRedirect("/login");

--- a/src/main/java/com/deem/zkui/controller/RestAccess.java
+++ b/src/main/java/com/deem/zkui/controller/RestAccess.java
@@ -39,9 +39,9 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("serial")
 @WebServlet(urlPatterns = {"/acd/appconfig"})
 public class RestAccess extends HttpServlet {
-    
+
     private final static Logger logger = LoggerFactory.getLogger(RestAccess.class);
-    
+
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         logger.debug("Rest Action!");
@@ -61,11 +61,11 @@ public class RestAccess extends HttpServlet {
             String[] propNames = request.getParameterValues("propNames");
             String propValue = "";
             LeafBean propertyNode;
-            
+
             if (hostName == null) {
                 hostName = ServletUtil.INSTANCE.getRemoteAddr(request);
             }
-            zk = ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0]);
+            zk = ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0], globalProps);
             //get the path of the hosts entry.
             LeafBean hostsNode = null;
             //If app name is mentioned then lookup path is appended with it.
@@ -74,14 +74,14 @@ public class RestAccess extends HttpServlet {
             } else {
                 hostsNode = ZooKeeperUtil.INSTANCE.getNodeValue(zk, ZooKeeperUtil.ZK_HOSTS, ZooKeeperUtil.ZK_HOSTS + "/" + hostName, hostName, accessRole);
             }
-            
+
             String lookupPath = hostsNode.getStrValue();
             logger.trace("Root Path:" + lookupPath);
             String[] pathElements = lookupPath.split("/");
 
             //Form all combinations of search path you want to look up the property in.
             List<String> searchPath = new ArrayList<>();
-            
+
             StringBuilder pathSubSet = new StringBuilder();
             for (String pathElement : pathElements) {
                 pathSubSet.append(pathElement);
@@ -100,9 +100,9 @@ public class RestAccess extends HttpServlet {
                 if (ZooKeeperUtil.INSTANCE.nodeExists(lookupPath + "/" + clusterName + "/" + hostName, zk)) {
                     searchPath.add(lookupPath + "/" + clusterName + "/" + hostName);
                 }
-                
+
             } else if (appName != null && clusterName == null) {
-                
+
                 if (ZooKeeperUtil.INSTANCE.nodeExists(lookupPath + "/" + hostName, zk)) {
                     searchPath.add(lookupPath + "/" + hostName);
                 }
@@ -112,7 +112,7 @@ public class RestAccess extends HttpServlet {
                 if (ZooKeeperUtil.INSTANCE.nodeExists(lookupPath + "/" + appName + "/" + hostName, zk)) {
                     searchPath.add(lookupPath + "/" + appName + "/" + hostName);
                 }
-                
+
             } else if (appName != null && clusterName != null) {
                 //Order in which these paths are listed is important as the lookup happens in that order.
                 //Precedence is give to cluster over app.
@@ -137,7 +137,7 @@ public class RestAccess extends HttpServlet {
                 if (ZooKeeperUtil.INSTANCE.nodeExists(lookupPath + "/" + clusterName + "/" + appName + "/" + hostName, zk)) {
                     searchPath.add(lookupPath + "/" + clusterName + "/" + appName + "/" + hostName);
                 }
-                
+
             }
 
             //Search the property in all lookup paths.
@@ -153,14 +153,14 @@ public class RestAccess extends HttpServlet {
                 if (propValue != null) {
                     resultOut.append(propName).append("=").append(propValue).append("\n");
                 }
-                
+
             }
-            
+
             response.setContentType("text/plain");
             try (PrintWriter out = response.getWriter()) {
                 out.write(resultOut.toString());
             }
-            
+
         } catch (KeeperException | InterruptedException ex) {
             logger.error(Arrays.toString(ex.getStackTrace()));
             ServletUtil.INSTANCE.renderError(request, response, ex.getMessage());
@@ -169,6 +169,6 @@ public class RestAccess extends HttpServlet {
                 ServletUtil.INSTANCE.closeZookeeper(zk);
             }
         }
-        
+
     }
 }

--- a/src/main/java/com/deem/zkui/utils/LdapAuth.java
+++ b/src/main/java/com/deem/zkui/utils/LdapAuth.java
@@ -17,11 +17,20 @@
  */
 package com.deem.zkui.utils;
 
+import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.List;
+
 import javax.naming.Context;
 import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.BasicAttributes;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
+import javax.naming.directory.SearchResult;
+
 import org.slf4j.LoggerFactory;
 
 public class LdapAuth {
@@ -29,32 +38,59 @@ public class LdapAuth {
     DirContext ctx = null;
     private final static org.slf4j.Logger logger = LoggerFactory.getLogger(LdapAuth.class);
 
-    public boolean authenticateUser(String ldapUrl, String username, String password, String domains) {
+    public List<String> authenticateUserAndReturnGroups(String ldapUrl, String username, String password, String domains,
+        String principalTemplate, String groupsToTest, String groupMatchAttrId, String groupSearchBase) {
 
-        String[] domainArr = domains.split(",");
+        List<String> matchedGroups = new ArrayList<String>();
+        String[] groupsToTestArr = new String[]{};
+        if (groupsToTest != null && groupsToTest.trim().length() > 0) {
+          groupsToTestArr = groupsToTest.trim().split(",");
+        }
+        String[] domainArr = domains.trim().split(",");
+        boolean successfulLogin = false;
         for (String domain : domainArr) {
             Hashtable env = new Hashtable();
             env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
             env.put(Context.PROVIDER_URL, ldapUrl);
             env.put(Context.SECURITY_AUTHENTICATION, "simple");
-            env.put(Context.SECURITY_PRINCIPAL, domain + "\\" + username);
+            env.put(Context.SECURITY_PRINCIPAL, String.format(principalTemplate, domain, username));
             env.put(Context.SECURITY_CREDENTIALS, password);
             try {
                 ctx = new InitialDirContext(env);
-                return true;
-            } catch (NamingException e) {
+                // We only need one successful login
+                successfulLogin = true;
+                groupLoop: for (String group : groupsToTestArr) {
+                    Attributes matchAttrs = new BasicAttributes(true);
+                    matchAttrs.put(groupMatchAttrId, group);
 
+                    Enumeration<SearchResult> results = ctx.search(groupSearchBase, matchAttrs);
+                    while (results.hasMoreElements()) {
+                        SearchResult result = results.nextElement();
+                        Attribute attr = result.getAttributes().get("memberUid");
+                        for (int i = 0; i < attr.size(); i++) {
+                            if (username.equals(attr.get(i))) {
+                                matchedGroups.add(group);
+                                continue groupLoop;
+                            }
+                        }
+                    }
+                }
+            } catch (NamingException e) {
+              logger.error("Unable to login over LDAP", e);
             } finally {
                 if (ctx != null) {
                     try {
                         ctx.close();
                     } catch (NamingException ex) {
-                        logger.warn(ex.getMessage());
+                        logger.warn(ex.getMessage(), ex);
                     }
                 }
             }
         }
-        return false;
-
+        if (successfulLogin) {
+          return matchedGroups;
+        } else {
+          return null;
+        }
     }
 }


### PR DESCRIPTION
Hi,

These changes support
1) more flexible LDAP authentication - so that this can be used with LDAP other than Active Directory.
2) allowing group membership in LDAP to set the ZKUI role rather than having a list of users.
3) setting a default ACL that is used for the creation of new nodes and properties.