### PR TITLE
added support for zkui behind a proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.idea/
+zkui.iml
 /target/

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,6 @@ build:
 	rm docker/config.cfg
 
 publish:
-	docker tag -f $(NAME):$(VERSION) $(NAME):$(VERSION)
-	docker tag -f $(NAME):$(VERSION) $(NAME):latest
+	docker tag $(NAME):$(VERSION) $(NAME):$(VERSION)
+	docker tag $(NAME):$(VERSION) $(NAME):latest
 	docker push $(NAME)

--- a/config.cfg
+++ b/config.cfg
@@ -42,3 +42,5 @@ keystoreManagerPwd=password
 # Permissions are based on single character flags: c (Create), r (read), w (write), d (delete), a (admin), * (all)
 # For example defaultAcl={"acls": [{"scheme":"ip", "id":"192.168.1.192", "perms":"*"}, {"scheme":"ip", id":"192.168.1.0/24", "perms":"r"}]
 defaultAcl=
+# Set X-Forwarded-For to true if zkui is behind a proxy
+X-Forwarded-For=false

--- a/src/main/java/com/deem/zkui/Main.java
+++ b/src/main/java/com/deem/zkui/Main.java
@@ -100,6 +100,9 @@ public class Main {
             https.setPort(Integer.parseInt(globalProps.getProperty("serverPort")));
             server.setConnectors(new Connector[]{https});
         } else {
+            if(globalProps.getProperty("X-Forwarded-For").equals("true")) {
+                http_config.addCustomizer(new org.eclipse.jetty.server.ForwardedRequestCustomizer());
+            }
             ServerConnector http = new ServerConnector(server, new HttpConnectionFactory(http_config));
             http.setPort(Integer.parseInt(globalProps.getProperty("serverPort")));
             server.setConnectors(new Connector[]{http});


### PR DESCRIPTION
zkui ignores the X-Forwarded-For header which is sent by the proxy to indicate the client hostname and protocol, resulting in a redirect to an http: protocol instead of https:

By adding the org.eclipse.jetty.server.ForwardedRequestCustomizer to the http_config this is resolved.

It is enabled by adding:

```
X-Forwarded-For=true
```

to the config.cfg.

By default it is set to false, to preserve backward compatibility.