### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Features
 
 Import File Format
 ====================
-#add property
+# add property
 /appconfig/path=property=value
-#remove a property
+# remove a property
 -/path/property
 
 You can either upload a file or specify a http url of the version control system that way all your zookeeper changes will be in version control. 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
