### PR TITLE
add auth to the zk client.

### DIFF
--- a/src/main/java/com/deem/zkui/utils/ServletUtil.java
+++ b/src/main/java/com/deem/zkui/utils/ServletUtil.java
@@ -20,19 +20,20 @@ package com.deem.zkui.utils;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
+
+import org.apache.zookeeper.ZooKeeper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-import org.apache.zookeeper.ZooKeeper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public enum ServletUtil {
 
@@ -98,7 +99,7 @@ public enum ServletUtil {
                 //Converting seconds to ms.
                 zkSessionTimeout = zkSessionTimeout * 1000;
                 zk = ZooKeeperUtil.INSTANCE.createZKConnection(zkServer, zkSessionTimeout);
-                ZooKeeperUtil.INSTANCE.setDefaultAcl(globalProps.getProperty("defaultAcl"));
+                ZooKeeperUtil.INSTANCE.setDefaultAcl(globalProps.getProperty("defaultAcl"), zk);
                 if (zk.getState() != ZooKeeper.States.CONNECTED) {
                     session.setAttribute("zk", null);
                 } else {

--- a/src/main/java/com/deem/zkui/utils/ZooKeeperUtil.java
+++ b/src/main/java/com/deem/zkui/utils/ZooKeeperUtil.java
@@ -19,14 +19,7 @@ package com.deem.zkui.utils;
 
 import com.deem.zkui.vo.LeafBean;
 import com.deem.zkui.vo.ZKNode;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
+
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
@@ -41,6 +34,15 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 public enum ZooKeeperUtil {
 
@@ -81,7 +83,12 @@ public enum ZooKeeperUtil {
         return defaultAcl;
     }
 
-    public void setDefaultAcl(String jsonAcl) {
+    /**
+     * set default ACL
+     * @param jsonAcl
+     * @param zk  if zk is not null, add the corresponding ACL to the zk
+     */
+    public void setDefaultAcl(String jsonAcl, ZooKeeper zk) {
         if (jsonAcl == null || jsonAcl.trim().length() == 0) {
             logger.trace("Using UNSAFE ACL. Anyone on your LAN can change your Zookeeper data");
             defaultAcl = ZooDefs.Ids.OPEN_ACL_UNSAFE;
@@ -96,6 +103,12 @@ public enum ZooKeeperUtil {
                 JSONObject acl = (JSONObject) it.next();
                 String scheme = ((String) acl.get("scheme")).trim();
                 String id = ((String) acl.get("id")).trim();
+
+                //add the corresponding ACL to the zk
+                if(zk != null){
+                    zk.addAuthInfo(scheme, id.getBytes());
+                }
+
                 int perms = 0;
                 String permStr = ((String) acl.get("perms")).toLowerCase().trim();
                 for (char c : permStr.toCharArray()) {


### PR DESCRIPTION
If the zk path has ACLs, the client can't access it by default. Add auth to the zk client by using the "defaultAcl" config, so that we will access the auth path by default. 