### PR TITLE
add zkRootPath configuration and Search in sub node

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -2,6 +2,8 @@
 serverPort=9090
 #Comma seperated list of all the zookeeper servers
 zkServer=localhost:2181,localhost:2181
+#the default zk root to show
+zkRootPath=/
 #Http path of the repository. Ignore if you dont intent to upload files from repository.
 scmRepo=http://myserver.com/@rev1=
 #Path appended to the repo url. Ignore if you dont intent to upload files from repository.

--- a/src/main/java/com/deem/zkui/controller/Home.java
+++ b/src/main/java/com/deem/zkui/controller/Home.java
@@ -37,6 +37,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
+import org.h2.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +57,11 @@ public class Home extends HttpServlet {
 
             Map<String, Object> templateParam = new HashMap<>();
             String zkPath = request.getParameter("zkPath");
+            String zkRootPath = globalProps.getProperty("zkRootPath");
+
+            if (!StringUtils.isNullOrEmpty(zkRootPath) && (StringUtils.isNullOrEmpty(zkPath) || zkPath.equals("/"))) {
+                zkPath = zkRootPath;
+            }
             String navigate = request.getParameter("navigate");
             ZooKeeper zk = ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0], globalProps);
             List<String> nodeLst;
@@ -164,7 +170,12 @@ public class Home extends HttpServlet {
                     response.sendRedirect("/home?zkPath=" + displayPath);
                     break;
                 case "Search":
-                    Set<LeafBean> searchResult = ZooKeeperUtil.INSTANCE.searchTree(searchStr, ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0], globalProps), authRole);
+                    String zkPath = request.getParameter("zkPath");
+                    String zkRootPath = globalProps.getProperty("zkRootPath");
+                    if (StringUtils.isNullOrEmpty(zkPath)) {
+                        zkPath = zkRootPath;
+                    }
+                    Set<LeafBean> searchResult = ZooKeeperUtil.INSTANCE.searchTree(searchStr, zkPath, ServletUtil.INSTANCE.getZookeeper(request, response, zkServerLst[0], globalProps), authRole);
                     templateParam.put("searchResult", searchResult);
                     ServletUtil.INSTANCE.renderHtml(request, response, templateParam, "search.ftl.html");
                     break;

--- a/src/main/resources/webapp/template/home.ftl.html
+++ b/src/main/resources/webapp/template/home.ftl.html
@@ -118,12 +118,13 @@
                         <div class="modal-content">
                             <div class="modal-header">
                                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                                <h4 class="modal-title" id="myModalLabel">Search</h4>
+                                <h4 class="modal-title" id="myModalLabel">Search in ${displayPath}</h4>
                             </div>
                             <div class="modal-body">
                                 <div class="input-group input-group-lg">
                                     <span class="input-group-addon">Search</span>
                                     <input type="text" id="search"  name="searchStr" class="form-control" >
+                                    <input type="hidden" name="zkPath" value="${displayPath}"/>
                                 </div>
                             </div>
                             <div class="modal-footer">


### PR DESCRIPTION
1. add zk root path in config.cfg
in some case for example zk as configuration center, we only need to show the value in /config, not /, so provide this configuration will be helpful and save search time

2. Search enhancement
it is not necessary to search from scratch, so we should search from current node, it can save a lot of time