### PR TITLE
correctly display value with new lines

### DIFF
--- a/src/main/resources/webapp/css/zkacd.css
+++ b/src/main/resources/webapp/css/zkacd.css
@@ -69,3 +69,9 @@ table td { word-wrap: break-word; }
 code {
     font-size: 80%;
 }
+
+.mono-pre-wrap {
+    font-family: monospace;
+    word-break: break-word;
+    white-space: pre-wrap;
+}

--- a/src/main/resources/webapp/template/home.ftl.html
+++ b/src/main/resources/webapp/template/home.ftl.html
@@ -92,7 +92,7 @@
                             <#else>
                             <td>
                                 <#if leaf.value??>
-                                ${leaf.strValue?html}
+                                <span class="mono-pre-wrap">${leaf.strValue?html}</span>
                                 </#if>
                             </td>
                             </#if>


### PR DESCRIPTION
If the value is a multi-line text such as a yaml, when displayed spaces  are compressed and newlines are removed. 
An example looks like this:
![test_yaml_old](https://github.com/DeemOpen/zkui/assets/5645008/eb790ac0-6f41-4d2f-b316-64a257598299)

This pull request proposes a solution that  preserves spaces and newlines, looks like this:
![test_yaml_new](https://github.com/DeemOpen/zkui/assets/5645008/861f9550-4e09-4267-8a4e-a955a78ae393)

